### PR TITLE
Add Support for NOW web service

### DIFF
--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -766,9 +766,7 @@
         "NICKAPP"
       ],
       "Norsk Rikskringkasting": "NRK",
-      "NowTV": [
-         "NOW.WEB"
-      ]
+      "NowTV": {"pattern": "NOW", "ignore_case": false}
       "OnDemandKorea": [
         "ODK",
         "OnDemandKorea"

--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -766,6 +766,9 @@
         "NICKAPP"
       ],
       "Norsk Rikskringkasting": "NRK",
+      "NowTV": [
+         "NOW.WEB"
+      ]
       "OnDemandKorea": [
         "ODK",
         "OnDemandKorea"


### PR DESCRIPTION
Requiring format of NOW.WEB as now NOW isn't very specific and potential of lots of false positives.  I say better safe than sorry