### PR TITLE
Make Youtube RED detection case sensitive

### DIFF
--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -838,7 +838,7 @@
       "WWE Network": "WWEN",
       "Xbox Video": "XBOX",
       "Yahoo": "YHOO",
-      "YouTube Red": "RED",
+      "YouTube Red":  {"pattern": "RED", "ignore_case": false},
       "ZDF": "ZDF"
     },
     "date": {


### PR DESCRIPTION
Decrease amount of false positives for youtube red

Currently any thing with "red" it gets youtube red detected as service, and upload script ignores provider if multiple are detected

Before
```
$ python3 ~/BLU-Upload-Bot/autoup.py ~/torrents/qbittorrent/Maine.Cabin.Masters.S09E02.The.Red.Camp.in.Belgrade.1080p.DISC.WEB-DL.AAC2.0.H.264-NTb.mkv --debug

Maine.Cabin.Masters.S09E02.The.Red.Camp.in.Belgrade.1080p.DISC.WEB-DL.AAC2.0.H.264-NTb.mkv Is a Dupe, debug mode enabled, continuing...

MatchesDict([('title', 'Maine Cabin Masters'), ('season', 9), ('episode', 2), ('episode_title', 'The'), ('streaming_service', ['YouTube Red', 'Discovery']), ('screen_size', '1080p'), ('source', 'Web'), ('audio_codec', 'AAC'), ('audio_channels', '2.0'), ('video_codec', 'H.264'), ('release_group', 'NTb'), ('container', 'mkv'), ('mimetype', 'video/x-matroska'), ('type', 'episode')])
Using keywords: "maine,cabin,camp,construction,home renovation"
Guessit found streaming service '['YouTube Red', 'Discovery']'...       Please report...
Using Release Name: "Maine Cabin Masters S09E02 1080p WEB-DL AAC 2.0 H.264-NTb"
```

After
```
$ python3 ~/BLU-Upload-Bot/autoup.py ~/torrents/qbittorrent/Maine.Cabin.Masters.S09E02.The.Red.Camp.in.Belgrade.1080p.DISC.WEB-DL.AAC2.0.H.264-NTb.mkv --debug

Maine.Cabin.Masters.S09E02.The.Red.Camp.in.Belgrade.1080p.DISC.WEB-DL.AAC2.0.H.264-NTb.mkv Is a Dupe, debug mode enabled, continuing...

MatchesDict([('title', 'Maine Cabin Masters'), ('season', 9), ('episode', 2), ('episode_title', 'The Red Camp in Belgrade'), ('screen_size', '1080p'), ('streaming_service', 'Discovery'), ('source', 'Web'), ('audio_codec', 'AAC'), ('audio_channels', '2.0'), ('video_codec', 'H.264'), ('release_group', 'NTb'), ('container', 'mkv'), ('mimetype', 'video/x-matroska'), ('type', 'episode')])
Using keywords: "maine,cabin,camp,construction,home renovation"
Using Release Name: "Maine Cabin Masters S09E02 1080p DISC WEB-DL AAC 2.0 H.264-NTb"
```